### PR TITLE
Convert `int` to `string` using `rune`.

### DIFF
--- a/strslice_test.go
+++ b/strslice_test.go
@@ -12,7 +12,7 @@ func TestStringSlice(t *testing.T) {
 
 	var s StringSlice
 	for i := 0; i < 1000; i++ {
-		s.Add(string('A' + i))
+		s.Add(string(rune('A' + i)))
 	}
 
 	assert.Equal(t, "len(s)", len(s), 1000)


### PR DESCRIPTION
This fixes test build on Go 1.15.